### PR TITLE
Allow to use DOMAIN_NAME with http/https

### DIFF
--- a/stress-test-k6.js
+++ b/stress-test-k6.js
@@ -18,6 +18,12 @@ if (__ENV.DOMAIN_NAME) {
     throw new Error(`DOMAIN_NAME is "${domainName}".  Specify DOMAIN_NAME to load.`);
 }
 
+//Remove http or https from domain name if present
+if (domainName.indexOf('http') > -1) {
+    domainName = domainName.replace('http://', '');
+    domainName = domainName.replace('https://', '');
+}
+
 // defaults can be overwriten via env variables
 users = __ENV.USERS ? __ENV.USERS : users;
 testDuration = __ENV.DURATION ? __ENV.DURATION : testDuration;


### PR DESCRIPTION
I tried to pass DOMAIN_NAME with https and got an error. Let's support DOMAIN_NAME with https/http